### PR TITLE
Use yaml.safe_load() instead of unsafe yaml.load()

### DIFF
--- a/utils/automatic-release/lib/defineVersion/index.js
+++ b/utils/automatic-release/lib/defineVersion/index.js
@@ -10,11 +10,11 @@ const diffToSemver = require('./diffToSemver');
 const defineVersion = (pkg, root, latestTemp) => {
   let version, diff;
 
-  const updatedContent = yaml.load(
+  const updatedContent = yaml.safe_load(
     path.join(root, `${packagePathResolver(pkg)}/token.yml`)
   );
 
-  const latestPath = path.join(latestTemp, 'node_modules', pkg, 'token.yml');
+  const latestPath = path.safe_load(latestTemp, 'node_modules', pkg, 'token.yml');
 
   if (fs.pathExistsSync(latestPath)) {
     const latestContent = yaml.load(latestPath);


### PR DESCRIPTION
The default behavior of PyYAML's yaml.load() method is unsafe and can execute code in yaml files.